### PR TITLE
Add code to remove the <select> arrow on IE10

### DIFF
--- a/formhack.css
+++ b/formhack.css
@@ -182,6 +182,10 @@ select {
 
 }
 
+select::-ms-expand{
+	display: none;
+}
+
 select[multiple] {
   height: auto;
   min-height: var(--fh-input-height);

--- a/formhack.sass
+++ b/formhack.sass
@@ -176,6 +176,8 @@ select
 		-ms-appearance: none
 		-o-appearance: none
 
+		::-ms-expand
+			display: none
 
 select[multiple]
 	height: auto
@@ -261,7 +263,7 @@ button:focus
 	border-color: $fh-focus-border-color
 
 input[type="checkbox"]:focus,
-input[type="radio"]:focus 
+input[type="radio"]:focus
 	outline: $fh-focus-border-color solid 2px
 
 button:hover,
@@ -271,6 +273,6 @@ input[type="reset"]:hover,
 button:focus,
 input[type="button"]:focus,
 input[type="submit"]:focus,
-input[type="reset"]:focus 
+input[type="reset"]:focus
 	background-color: $fh-button-hover-bg-color
 	color: $fh-button-hover-font-color

--- a/formhack.scss
+++ b/formhack.scss
@@ -184,6 +184,9 @@ select {
 		-moz-appearance: none;
 		-ms-appearance: none;
 		-o-appearance: none;
+		&::-ms-expand {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
``` scss
// Select Vendor Styling
$fh-allow-select-vendor-styling: false !default;
```

When the above settings on IE10, the `<select>` arrow appear.

<img width="408" alt="capture 2016-08-31 at 05 29 18" src="https://cloud.githubusercontent.com/assets/5554826/18105845/fa1aefa4-6f3b-11e6-8ec0-397d4319aecd.png">

Should be adding

``` css
select::-ms-expand{
    display: none;
}
```

<img width="407" alt="capture 2016-08-31 at 05 31 51" src="https://cloud.githubusercontent.com/assets/5554826/18105920/48f0847c-6f3c-11e6-9a53-d7708e022ec0.png">
