### PR TITLE
Removing clear and reveal password icons from IE10

### DIFF
--- a/formhack.css
+++ b/formhack.css
@@ -23,6 +23,9 @@
   --fh-focus-border-color: var(--fh-border-color);
   --fh-focus-font-color: var(--fh-font-color);
 
+  /* Inputs Vendor Styling */
+  --fh-input-vendor-styling: none; /* comment this out to maintain vendor styling */
+
   /* Select Vendor Styling */
   --fh-select-vendor-styling: none; /* comment this out to maintain vendor styling */
 
@@ -129,6 +132,24 @@ input[type="week"],
 input[list] {
   height: var(--fh-input-height);
   -webkit-appearance: none;
+}
+
+/* Fields with standard height */
+input[type="text"]::-ms-clear,
+input[type="email"]::-ms-clear,
+input[type="password"]::-ms-reveal,
+input[type="search"]::-ms-clear,
+input[type="color"]::-ms-clear,
+input[type="date"]::-ms-clear,
+input[type="datetime-local"]::-ms-clear,
+input[type="month"]::-ms-clear,
+input[type="number"]::-ms-clear,
+input[type="tel"]::-ms-clear,
+input[type="time"]::-ms-clear,
+input[type="url"]::-ms-clear,
+input[type="week"]::-ms-clear,
+input[list]::-ms-clear {
+  display: var(--fh-input-vendor-styling);
 }
 
 /* Other */

--- a/formhack.sass
+++ b/formhack.sass
@@ -22,6 +22,9 @@ $fh-focus-bg-color: rgb(220, 220, 220) !default
 $fh-focus-border-color: $fh-border-color !default
 $fh-focus-font-color: $fh-font-color !default
 
+// Inputs Vendor Styling
+$fh-allow-input-vendor-styling: true !default
+
 // Select Vendor Styling
 $fh-allow-select-vendor-styling: true !default
 
@@ -126,6 +129,9 @@ input[type="week"],
 input[list]
 	height: $fh-input-height
 	-webkit-appearance: none
+	@if $fh-allow-input-vendor-styling == false
+		&::-ms-clear, &::-ms-reveal
+		    display: none
 
 
 /* Other */

--- a/formhack.scss
+++ b/formhack.scss
@@ -22,6 +22,9 @@ $fh-focus-bg-color: rgb(220, 220, 220) !default;
 $fh-focus-border-color: $fh-border-color !default;
 $fh-focus-font-color: $fh-font-color !default;
 
+// Inputs Vendor Styling
+$fh-allow-input-vendor-styling: true !default;
+
 // Select Vendor Styling
 $fh-allow-select-vendor-styling: true !default;
 
@@ -134,6 +137,11 @@ input[type="week"],
 input[list] {
 	height: $fh-input-height;
 	-webkit-appearance: none;
+	@if $fh-allow-input-vendor-styling == false {
+		&::-ms-clear, &::-ms-reveal {
+			display: none;
+		}
+    }
 }
 
 /* Other */


### PR DESCRIPTION
This pull request is for removing `clear` and `reveal` password icons from IE10.

<img width="416" alt="capture 2016-11-02 at 6 05 39" src="https://cloud.githubusercontent.com/assets/5554826/19924584/e3f9a262-a12f-11e6-9707-c4e61cd8fb1d.png">

<img width="410" alt="capture 2016-11-02 at 6 05 06" src="https://cloud.githubusercontent.com/assets/5554826/19924592/ebe24f1a-a12f-11e6-99d4-fc1cd491792c.png">

Please refer to the following.
http://stackoverflow.com/questions/17000562/removing-clear-and-reveal-password-icons-from-ie10

I do not well understand the variables on `.css` file.
So check it please.